### PR TITLE
Cal level for Triple-MUSIC for rectangular/triangular shape anodes

### DIFF
--- a/sofdata/CMakeLists.txt
+++ b/sofdata/CMakeLists.txt
@@ -49,6 +49,7 @@ twimData/R3BSofTwimMappedData.cxx
 twimData/R3BSofTwimCalData.cxx
 twimData/R3BSofTwimHitData.cxx
 trimData/R3BSofTrimMappedData.cxx
+trimData/R3BSofTrimCalData.cxx
 frsData/R3BSofFrsData.cxx
 trackingData/R3BSofTrackingData.cxx
 scalersData/R3BSofScalersMappedData.cxx

--- a/sofdata/R3BSofDataLinkDef.h
+++ b/sofdata/R3BSofDataLinkDef.h
@@ -32,6 +32,7 @@
 #pragma link C++ class R3BSofTofWHitData + ;
 
 #pragma link C++ class R3BSofTrimMappedData + ;
+#pragma link C++ class R3BSofTrimCalData + ;
 
 #pragma link C++ class R3BSofTwimMappedData + ;
 #pragma link C++ class R3BSofTwimCalData + ;

--- a/sofdata/trimData/R3BSofTrimCalData.cxx
+++ b/sofdata/trimData/R3BSofTrimCalData.cxx
@@ -1,0 +1,44 @@
+// -------------------------------------------------------------------------
+// -----                 R3BSofTrimCalData source file         -----
+// -------------------------------------------------------------------------
+
+#include "R3BSofTrimCalData.h"
+
+// -----   Default constructor   -------------------------------------------
+R3BSofTrimCalData::R3BSofTrimCalData()
+    : fSecID(0)
+    , fAnodeID(0)
+    , fDriftTimeRaw(-1000000)
+    , fDriftTimeAligned(-1000000)
+    , fEnergySub(0)
+    , fEnergyMatch(0)
+{
+}
+// -------------------------------------------------------------------------
+
+// -----   Standard constructors   ------------------------------------------
+R3BSofTrimCalData::R3BSofTrimCalData(Int_t secID, Int_t anodeID)
+    : fSecID(secID)
+    , fAnodeID(anodeID)
+    , fDriftTimeRaw(-1000000)
+    , fDriftTimeAligned(-1000000)
+    , fEnergySub(0)
+    , fEnergyMatch(0)
+{
+}
+
+
+R3BSofTrimCalData::R3BSofTrimCalData(Int_t    secID,   Int_t    anodeID,
+				     Double_t dtraw,   Double_t dtal, 
+				     Float_t  esub,    Float_t  ematch)
+    : fSecID(secID)
+    , fAnodeID(anodeID)
+    , fDriftTimeRaw(dtraw)
+    , fDriftTimeAligned(dtal)
+    , fEnergySub(esub)
+    , fEnergyMatch(ematch)
+{
+}
+// -------------------------------------------------------------------------
+
+ClassImp(R3BSofTrimCalData)

--- a/sofdata/trimData/R3BSofTrimCalData.h
+++ b/sofdata/trimData/R3BSofTrimCalData.h
@@ -1,0 +1,56 @@
+#ifndef R3BSofTrimCalData_H
+#define R3BSofTrimCalData_H
+#include "TObject.h"
+
+class R3BSofTrimCalData : public TObject
+{
+
+  public:
+    /** Default constructor **/
+    R3BSofTrimCalData();
+
+    /** Constructor with arguments 
+	secID     is 1-based 
+	anodeID   is 1-based if triangle anodes : 3 pairs of anodes
+    **/
+    R3BSofTrimCalData(Int_t secID, Int_t anodeID);    
+    R3BSofTrimCalData(Int_t    secID, Int_t    anodeID, 
+		      Double_t dtraw, Double_t dtal, 
+		      Float_t  esub,  Float_t  ematch); 
+
+    /** Destructor **/
+    virtual ~R3BSofTrimCalData() {}
+
+    /** Accessors **/
+    inline const Int_t& GetSecID() const     { return fSecID; }
+    inline const Int_t& GetAnodeID() const   { return fAnodeID; }
+
+    inline const Double_t& GetDriftTimeRaw() const     { return fDriftTimeRaw; }
+    inline const Double_t& GetDriftTimeAligned() const { return fDriftTimeAligned; }
+
+    inline const Float_t&  GetEnergySub() const     { return fEnergySub; }
+    inline const Float_t&  GetEnergyMatch() const   { return fEnergyMatch; }
+
+    /** Modifiers **/
+    void SetSecID(Int_t id)     { fSecID = id; };
+    void SetAnodeID(Int_t id)   { fAnodeID = id; };
+
+    void SetDriftTimeRaw(Double_t dt)     { fDriftTimeRaw = dt; };
+    void SetDriftTimeAligned(Double_t dt) { fDriftTimeAligned = dt; };
+
+    void SetEnergySub(Float_t e)   { fEnergySub = e; };
+    void SetEnergyMatch(Float_t e) { fEnergyMatch = e; };
+
+  protected:
+    Int_t    fSecID;
+    Int_t    fAnodeID;
+
+    Double_t fDriftTimeRaw; 
+    Double_t fDriftTimeAligned; 
+    Float_t  fEnergySub;    
+    Float_t  fEnergyMatch;    
+
+    ClassDef(R3BSofTrimCalData, 1)
+};
+
+#endif

--- a/sofonline/R3BSofTrimOnlineSpectra.h
+++ b/sofonline/R3BSofTrimOnlineSpectra.h
@@ -78,6 +78,7 @@ class R3BSofTrimOnlineSpectra : public FairTask
 
     void SetNumSections(Int_t num) {fNumSections=num;}
     void SetNumAnodes(Int_t num) {fNumAnodes=num;}
+    void SetNumPairs(Int_t num) {fNumPairs=num;}
     void SetNumTref(Int_t num) {fNumTref=num;}
     void SetNumTtrig(Int_t num) {fNumTtrig=num;}
 
@@ -86,10 +87,12 @@ class R3BSofTrimOnlineSpectra : public FairTask
     
     Int_t    fNumSections;
     Int_t    fNumAnodes;
+    Int_t    fNumPairs;
     Int_t    fNumTref;
     Int_t    fNumTtrig;
 
     TClonesArray* fMappedItemsTrim; /**< Array with mapped items. */
+    TClonesArray* fCalItemsTrim;    /**< Array with cal items. */
 
     // check for trigger should be done globablly (somewhere else)
     R3BEventHeader* header; /**< Event header.      */
@@ -110,6 +113,17 @@ class R3BSofTrimOnlineSpectra : public FairTask
     TH1F** fh1_trimmap_DeltaTrefTtrig;//[NbSectionsTrim];
     TH2F** fh2_trimmap_EvsDT;//[NbSectionsTrim][NbAnodesTrim];
     TH2F** fh2_trimmap_DTvsDT;//[NbSectionsTrim][NbAnodesTrim-1];
+
+    // Canvas for Cal data
+    TCanvas** cTrimCal_Ene;
+    TCanvas** cTrimCal_DT;
+
+    // Histograms for Cal data
+    TH1F** fh1_trimcal_Esub;
+    TH1F** fh1_trimcal_Ematch;
+    TH1D** fh1_trimcal_DTraw;
+    TH1D** fh1_trimcal_DTalign;
+
 
   public:
     ClassDef(R3BSofTrimOnlineSpectra, 1)

--- a/tcal/R3BSofSciMapped2Tcal.cxx
+++ b/tcal/R3BSofSciMapped2Tcal.cxx
@@ -88,7 +88,7 @@ InitStatus R3BSofSciMapped2Tcal::Init()
     // --- ---------------- --- //
     // --- OUTPUT TCAL DATA --- //
     // --- ---------------- --- //
-    fTcal = new TClonesArray("R3BSofSciTcalData", 10);
+    fTcal = new TClonesArray("R3BSofSciTcalData", 25);
     if (!fOnline)
     {
         rm->Register("SofSciTcalData", "SofSci", fTcal, kTRUE);

--- a/trim/CMakeLists.txt
+++ b/trim/CMakeLists.txt
@@ -10,6 +10,7 @@ ${R3BROOT_SOURCE_DIR}/r3bbase
 ${R3BROOT_SOURCE_DIR}/r3bdata
 ${R3BSOF_SOURCE_DIR}/sofdata
 ${R3BSOF_SOURCE_DIR}/sofdata/trimData
+${R3BSOF_SOURCE_DIR}/sofdata/mwpcData
 ${R3BSOF_SOURCE_DIR}/tcal
 ${R3BSOF_SOURCE_DIR}/trim
 )
@@ -23,6 +24,11 @@ link_directories( ${LINK_DIRECTORIES})
 
 set(SRCS
 #Put here your sourcefiles
+R3BSofTrimContFact.cxx
+R3BSofTrimCalPar.cxx
+R3BSofTrimMapped2Cal.cxx
+R3BSofTrimCalculateMatchGainPar.cxx
+R3BSofTrimCalculateDriftTimeOffsetPar.cxx
 )
 
 # fill list of header files from list of source files

--- a/trim/R3BSofTrimCalPar.cxx
+++ b/trim/R3BSofTrimCalPar.cxx
@@ -1,0 +1,153 @@
+// ------------------------------------------------------------------
+// -----             R3BSofTrimCalPar source file               -----
+// ------------------------------------------------------------------
+
+#include "R3BSofTrimCalPar.h"
+
+#include "FairLogger.h"
+#include "FairParamList.h"
+
+#include "TArrayF.h"
+#include "TArrayI.h"
+#include "TMath.h"
+#include "TString.h"
+
+#include <iostream>
+
+// ---- Standard Constructor ---------------------------------------------------
+R3BSofTrimCalPar::R3BSofTrimCalPar(const char* name, const char* title, const char* context)
+    : FairParGenericSet(name, title, context)
+    , fNumSections(3)
+    , fNumAnodes(6)
+{
+    fDriftTimeOffsets = new TArrayD(fNumSections * fNumAnodes);
+    fEnergyPedestals = new TArrayF(fNumSections * fNumAnodes);
+    fEnergyMatchGains = new TArrayF(fNumSections * fNumAnodes);
+    fEnergyAlignGains = new TArrayF(fNumSections * fNumAnodes);
+}
+
+// ----  Destructor ------------------------------------------------------------
+R3BSofTrimCalPar::~R3BSofTrimCalPar()
+{
+    clear();
+    if (fDriftTimeOffsets)   delete fDriftTimeOffsets;
+    if (fEnergyPedestals)    delete fEnergyPedestals;
+    if (fEnergyMatchGains)    delete fEnergyMatchGains;
+    if (fEnergyAlignGains)    delete fEnergyAlignGains;
+}
+
+// ----  Method clear ----------------------------------------------------------
+void R3BSofTrimCalPar::clear()
+{
+    status = kFALSE;
+    resetInputVersions();
+}
+
+// ----  Method putParams ------------------------------------------------------
+void R3BSofTrimCalPar::putParams(FairParamList* list)
+{
+    LOG(INFO) << "R3BSofTrimCalPar::putParams() called";
+    if (!list)
+    {
+        return;
+    }
+    Int_t array_size;
+    array_size = fNumSections * fNumAnodes;
+    LOG(INFO) << "Array Size: " << array_size;
+    fDriftTimeOffsets->Set(array_size);
+    fEnergyPedestals->Set(array_size);
+    fEnergyMatchGains->Set(array_size);
+    fEnergyAlignGains->Set(array_size);
+
+    list->add("trimNumSections", fNumSections);
+    list->add("trimNumAnodesPerSection", fNumAnodes);
+    list->add("trimDriftTimeOffsets",*fDriftTimeOffsets);
+    list->add("trimEnergyPedestals",*fEnergyPedestals);
+    list->add("trimEnergyMatchGains",*fEnergyMatchGains);
+    list->add("trimEnergyAlignGains",*fEnergyAlignGains);
+
+}
+
+// ----  Method getParams ------------------------------------------------------
+Bool_t R3BSofTrimCalPar::getParams(FairParamList* list)
+{
+  
+  LOG(INFO) << "R3BSofTrimCalPar::getParams() called";
+  if (!list){
+    return kFALSE;
+  }
+  
+  if (!list->fill("trimNumSections", &fNumSections)){
+    return kFALSE;
+  }
+  
+  if (!list->fill("trimNumAnodesPerSection", &fNumAnodes)){
+    return kFALSE;
+  }
+  
+  Int_t array_anode = fNumSections * fNumAnodes;
+  LOG(INFO) << "Array Size for anode in use: " << array_anode;
+  
+  fDriftTimeOffsets->Set(array_anode);
+  if (!(list->fill("trimDriftTimeOffsets", fDriftTimeOffsets))){
+    LOG(INFO) << "---Could not initialize trimDriftTimeOffsets";
+    return kFALSE;
+  }
+  
+  fEnergyPedestals->Set(array_anode);
+  if (!(list->fill("trimEnergyPedestals", fEnergyPedestals))){
+    LOG(INFO) << "---Could not initialize trimEnergyPedestals";
+    return kFALSE;
+  }
+  
+  fEnergyMatchGains->Set(array_anode);
+  if (!(list->fill("trimEnergyMatchGains", fEnergyMatchGains))){
+    LOG(INFO) << "---Could not initialize trimEnergyMatchGains";
+    return kFALSE;
+  }
+  
+  fEnergyAlignGains->Set(array_anode);
+  if (!(list->fill("trimEnergyAlignGains", fEnergyAlignGains))){
+    LOG(INFO) << "---Could not initialize trimEnergyAlignGains";
+    return kFALSE;
+  }
+  
+  return kTRUE;
+}
+
+// ----  Method printParams ----------------------------------------------------
+void R3BSofTrimCalPar::printParams()
+{
+  LOG(INFO) << "R3BSofTrimCalPar: Triple MUSIC offsets for drift time: ";
+  
+  for (Int_t s = 0; s < fNumSections; s++){
+    LOG(INFO) << "Trim section: " << s+1;
+    for (Int_t a = 0; a < fNumAnodes; a++){
+      LOG(INFO) << "Anode number: " << a+1 << ": Drift time offset = " << GetDriftTimeOffset(s+1, a+1);
+    }
+  }
+  
+  LOG(INFO) << "R3BSofTrimCalPar: Triple MUSIC energy pedestal: ";
+  for (Int_t s = 0; s < fNumSections; s++){
+    LOG(INFO) << "Trim section: " << s+1;
+    for (Int_t a = 0; a < fNumAnodes; a++){
+      LOG(INFO) << "Anode number: " << a+1 << ": Energy pedestal = " << GetEnergyPedestal(s+1, a+1);
+    }
+  }
+
+  LOG(INFO) << "R3BSofTrimCalPar: Triple MUSIC energy match gain per pair of down/up anode: ";
+  for (Int_t s = 0; s < fNumSections; s++){
+    LOG(INFO) << "Trim section: " << s+1;
+    for (Int_t a = 0; a < fNumAnodes; a++){
+      LOG(INFO) << "Anode number: " << a+1 << ": Energy Match Gain = " << GetEnergyMatchGain(s+1, a+1);
+    }
+  }
+
+  LOG(INFO) << "R3BSofTrimCalPar: Triple MUSIC energy aligne gain per pair of down/up anode: ";
+  for (Int_t s = 0; s < fNumSections; s++){
+    LOG(INFO) << "Trim section: " << s+1;
+    for (Int_t a = 0; a < fNumAnodes; a++){
+      LOG(INFO) << "Anode number: " << a+1 << ": Energy Align Gain = " << GetEnergyAlignGain(s+1, a+1);
+    }
+  }
+}

--- a/trim/R3BSofTrimCalPar.h
+++ b/trim/R3BSofTrimCalPar.h
@@ -1,0 +1,78 @@
+// ------------------------------------------------------------------
+// -----             R3BSofTrimCalPar source file               -----
+// ------------------------------------------------------------------
+
+#ifndef R3BSofTrimCalPar_H
+#define R3BSofTrimCalPar_H
+
+#include "FairParGenericSet.h" // for FairParGenericSet
+
+#include "TArrayF.h"
+#include "TArrayD.h"
+#include "TObjArray.h"
+#include "TObject.h"
+#include <TObjString.h>
+
+class FairParamList;
+
+class R3BSofTrimCalPar : public FairParGenericSet
+{
+
+  public:
+    /** Standard constructor **/
+    R3BSofTrimCalPar(const char* name = "trimCalPar",
+		     const char* title = "Triple MUSIC Cal Parameters",
+		     const char* context = "TrimCalParContext");
+    
+    /** Destructor **/
+    virtual ~R3BSofTrimCalPar();
+
+    /** Method to reset all parameters **/
+    virtual void clear();
+
+    /** Method to store all parameters using FairRuntimeDB **/
+    virtual void putParams(FairParamList* list);
+
+    /** Method to retrieve all parameters using FairRuntimeDB**/
+    Bool_t getParams(FairParamList* list);
+
+    /** Method to print values of parameters to the standard output **/
+    void printParams();
+
+    /** Accessor functions **/
+    const Int_t GetNumSections() { return fNumSections; }
+    const Int_t GetNumAnodes()   { return fNumAnodes; }
+    Double_t GetDriftTimeOffset(Int_t section, Int_t anode) { return fDriftTimeOffsets->GetAt((anode-1)+(section-1)*6 ); }
+    Float_t  GetEnergyPedestal(Int_t section, Int_t anode)  { return fEnergyPedestals->GetAt((anode-1)+(section-1)*6 ); }
+    Float_t  GetEnergyMatchGain(Int_t section, Int_t anode) { return fEnergyMatchGains->GetAt((anode-1)+(section-1)*6 ); }
+    Float_t  GetEnergyAlignGain(Int_t section, Int_t anode) { return fEnergyAlignGains->GetAt((anode-1)+(section-1)*6 ); }
+    TArrayD* GetDriftTimeOffsets() { return fDriftTimeOffsets; }
+    TArrayF* GetEnergyPedestals()  { return fEnergyPedestals; }
+    TArrayF* GetEnergyMatchGains() { return fEnergyMatchGains; }
+    TArrayF* GetEnergyAlignGains() { return fEnergyAlignGains; }
+
+    void SetNumSections(Int_t num) { fNumSections = num; }
+    void SetNumAnodes(Int_t num)   { fNumAnodes = num; }
+    void SetDriftTimeOffset(Double_t val, Int_t section, Int_t anode) { fDriftTimeOffsets->AddAt(val, (anode-1)+(section-1)*6); }
+    void SetEnergyPedestal(Float_t val, Int_t section, Int_t anode)   { fEnergyPedestals->AddAt(val, (anode-1)+(section-1)*6); }
+    void SetEnergyMatchGain(Float_t val, Int_t section, Int_t anode)  { fEnergyMatchGains->AddAt(val, (anode-1)+(section-1)*6);}
+    void SetEnergyAlignGain(Float_t val, Int_t section, Int_t anode)  { fEnergyAlignGains->AddAt(val, (anode-1)+(section-1)*6);}
+
+    // Create more Methods if you need them!
+
+  private:
+    Int_t fNumSections;             // number of sections
+    Int_t fNumAnodes;               // number of anodes per section
+    TArrayD* fDriftTimeOffsets;      // Drift Time offset to align drift time for a similar position
+    TArrayF* fEnergyPedestals;        // Energy pedestals
+    TArrayF* fEnergyMatchGains;       // Gain matching of the triangular pair of anodes
+    TArrayF* fEnergyAlignGains;       // EnergyGain matching of the triangular pair of anodes
+
+    const R3BSofTrimCalPar& operator=(const R3BSofTrimCalPar&); /*< an assignment operator>*/
+
+    R3BSofTrimCalPar(const R3BSofTrimCalPar&); /*< a copy constructor >*/
+
+    ClassDef(R3BSofTrimCalPar, 1);
+};
+
+#endif

--- a/trim/R3BSofTrimCalculateDriftTimeOffsetPar.cxx
+++ b/trim/R3BSofTrimCalculateDriftTimeOffsetPar.cxx
@@ -1,0 +1,235 @@
+#include "R3BSofTrimCalculateDriftTimeOffsetPar.h"
+
+#include "R3BSofTrimCalPar.h"
+#include "R3BSofTrimCalData.h"
+#include "R3BSofMwpcHitData.h"
+
+#include "R3BEventHeader.h"
+
+#include "FairLogger.h"
+#include "FairRootManager.h"
+#include "FairRunAna.h"
+#include "FairRuntimeDb.h"
+#include "TGeoManager.h"
+
+#include "TClonesArray.h"
+#include "TGeoMatrix.h"
+#include "TMath.h"
+#include "TObjArray.h"
+#include "TRandom.h"
+#include "TVector3.h"
+#include "TF1.h"
+
+#include <iostream>
+#include <stdlib.h>
+
+
+// R3BSofTrimCalculateDriftTimeOffsetPar: Default Constructor --------------------------
+R3BSofTrimCalculateDriftTimeOffsetPar::R3BSofTrimCalculateDriftTimeOffsetPar()
+    : FairTask("R3BSofTrimCalculateDriftTimeOffsetPar", 1)
+    , fNumSections(3)
+    , fNumAnodes(6) 
+    , fMinStatistics(0)
+    , fTrimCalData(NULL)
+    , fMwpc0HitData(NULL)
+    , fMwpc1HitData(NULL)
+    , fCalPar(NULL)
+    , fMwpc0OffsetX(0)
+    , fMwpc1OffsetX(0)
+    , fDistMwpc0Anode1(0)
+    , fDistMwpc0Mwpc1(0)
+    , fWidthAnode(25)        // mm
+    , fDistInterSection(50) // mm FIX ME: exact value ? (2 edge anodes + stripper + field cage)
+    , fDriftVelocity(45)   // mm/micros
+    , fOutputFile(NULL)
+{
+}
+
+// R3BSofTrimCalculateDriftTimeOffsetPar: Standard Constructor --------------------------
+R3BSofTrimCalculateDriftTimeOffsetPar::R3BSofTrimCalculateDriftTimeOffsetPar(const char* name, Int_t iVerbose)
+    : FairTask(name, iVerbose)
+    , fNumSections(0)
+    , fNumAnodes(0) 
+    , fMinStatistics(0)
+    , fTrimCalData(NULL)
+    , fMwpc0HitData(NULL)
+    , fMwpc1HitData(NULL)
+    , fCalPar(NULL)
+    , fMwpc0OffsetX(0)
+    , fMwpc1OffsetX(0)
+    , fDistMwpc0Anode1(0)
+    , fDistMwpc0Mwpc1(0)
+    , fWidthAnode(25)        // mm
+    , fDistInterSection(50) // mm FIX ME: exact value ? (2 edge anodes + stripper + field cage)
+    , fDriftVelocity(45)   // mm/micros
+    , fOutputFile(NULL)
+{
+}
+
+// R3BSofTrimCalculateDriftTimeOffsetPar: Destructor ----------------------------------------
+R3BSofTrimCalculateDriftTimeOffsetPar::~R3BSofTrimCalculateDriftTimeOffsetPar()
+{
+  if (fCalPar)        delete fCalPar;
+}
+
+// -----   Public method Init   --------------------------------------------
+InitStatus R3BSofTrimCalculateDriftTimeOffsetPar::Init()
+{
+
+    LOG(INFO) << "R3BSofTrimCalculateDriftTimeOffsetPar: Init";
+
+    FairRootManager* rm = FairRootManager::Instance();
+    if (!rm){
+      return kFATAL;
+    }
+
+    // --- ------------------- --- //
+    // --- INPUT TRIM CAL DATA --- //
+    // --- ------------------- --- //
+
+    fTrimCalData = (TClonesArray*)rm->GetObject("TrimCalData");
+    if (!fTrimCalData){
+      LOG(ERROR) << "R3BSofTrimCalculateDriftTimeOffsetPar::Init() Couldn't get handle on TrimCalData";
+      return kFATAL;
+    }
+
+    // --- -------------------- --- //
+    // --- INPUT MWPC0 HIT DATA --- //
+    // --- -------------------- --- //
+
+    fMwpc0HitData = (TClonesArray*)rm->GetObject("Mwpc0HitData");
+    if (!fMwpc0HitData){
+      LOG(ERROR) << "R3BSofTrimCalculateDriftTimeOffsetPar::Init() Couldn't get handle on Mwpc0HitData";
+      return kFATAL;
+    }
+
+    // --- -------------------- --- //
+    // --- INPUT MWPC1 HIT DATA --- //
+    // --- -------------------- --- //
+
+    fMwpc1HitData = (TClonesArray*)rm->GetObject("Mwpc1HitData");
+    if (!fMwpc1HitData){
+      LOG(ERROR) << "R3BSofTrimCalculateDriftTimeOffsetPar::Init() Couldn't get handle on Mwpc1HitData";
+      return kFATAL;
+    }
+
+    // --- ------------------------------------------ --- //
+    // --- SOF TRIM TRIANGLE CAL PARAMETERS CONTAINER --- //
+    // --- ------------------------------------------ --- //
+
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    if (!rtdb){
+      return kFATAL;
+    }
+
+    fCalPar = (R3BSofTrimCalPar*)rtdb->getContainer("trimCalPar");
+    if (!fCalPar){
+      LOG(ERROR) << "R3BSofTrimCalculateDriftTimeOffsetPar::Init() Couldn't get handle on trimCalPar container";
+      return kFATAL;
+    }
+    else{
+      fNumSections = fCalPar->GetNumSections();
+      fNumAnodes = fCalPar->GetNumAnodes();    
+      LOG(INFO) << "R3BSofTrimCalculateDriftTimeOffsetPar::Init() trimCalPar container found with fNumSections = " << fNumSections;
+    }
+
+    // --- ---------------------- --- //
+    // --- HISTOGRAMS DECLARATION --- //
+    // --- ---------------------- --- //
+
+    char name[100];
+    fh1_DeltaDT = new TH1D*[fNumSections*fNumAnodes];
+    for(Int_t section=0; section<fNumSections; section++){
+      for(Int_t anode=0; anode<fNumAnodes; anode++){
+	sprintf(name,"DeltaDT_S%iA%i",section+1,anode+1);
+	fh1_DeltaDT[anode+section*fNumAnodes] = new TH1D(name,name,5000,-2500,2500);
+	fh1_DeltaDT[anode+section*fNumAnodes]->GetXaxis()->SetTitle("Delta Drift Time [channels, 100 ps TDC resolution]");
+      }
+    }
+    
+    return kSUCCESS;
+}
+
+// -----   Public method ReInit  --------------------------------------------
+InitStatus R3BSofTrimCalculateDriftTimeOffsetPar::ReInit() { return kSUCCESS; }
+
+// -----   Public method Exec   --------------------------------------------
+void R3BSofTrimCalculateDriftTimeOffsetPar::Exec(Option_t* opt)
+{
+
+  Int_t iSec,iAnode;
+  Double_t X0, X1, DTraw, Xanode,Zanode;
+  UInt_t nHits;
+
+  // --- -------------- --- //
+  // --- MWPC0 HIT DATA --- //
+  // --- -------------- --- //
+  // only event with one single hit are considered
+  nHits = fMwpc0HitData->GetEntries();
+  if(nHits!=1) return;
+  R3BSofMwpcHitData* hitMwpc0 = (R3BSofMwpcHitData*)fMwpc0HitData->At(0);
+  X0 = hitMwpc0->GetX()+fMwpc0OffsetX;
+
+  // --- -------------- --- //
+  // --- MWPC1 HIT DATA --- //
+  // --- -------------- --- //
+  // only event with empty target (beam data with minimum straggling) and one single event are considered
+  nHits = fMwpc1HitData->GetEntries();
+  if(nHits!=1) return;
+  R3BSofMwpcHitData* hitMwpc1 = (R3BSofMwpcHitData*)fMwpc1HitData->At(0);
+  X1 = hitMwpc1->GetX()+fMwpc1OffsetX;
+
+  // --- --------------------------------------- --- //
+  // --- LOOP OVER TRIANGLE CAL HITS FOR SofTrim --- //
+  // --- --------------------------------------- --- //
+  nHits = fTrimCalData->GetEntries(); 
+  if (!nHits) return;
+  for(Int_t ihit=0; ihit<nHits; ihit++){
+    R3BSofTrimCalData* hit = (R3BSofTrimCalData*)fTrimCalData->At(ihit);
+    iSec = hit->GetSecID()-1; 
+    iAnode = hit->GetAnodeID()-1;
+    DTraw = hit->GetDriftTimeRaw();
+    Zanode = fDistMwpc0Anode1 + (iAnode+iSec*fNumAnodes)*fWidthAnode + iSec*fDistInterSection;
+    Xanode = Zanode*(X1-X0)/fDistMwpc0Mwpc1;
+    fh1_DeltaDT[iAnode+iSec*fNumAnodes]->Fill(10000.*Xanode/fDriftVelocity - DTraw);//10000 : mm/micros -> mm/100ps
+  }// end of loop over the mapped data
+
+}
+
+// ---- Public method Reset   --------------------------------------------------
+void R3BSofTrimCalculateDriftTimeOffsetPar::Reset() {}
+
+void R3BSofTrimCalculateDriftTimeOffsetPar::FinishEvent() {}
+
+// ---- Public method Finish   --------------------------------------------------
+void R3BSofTrimCalculateDriftTimeOffsetPar::FinishTask()
+{
+   CalculateOffsets();
+   fCalPar->printParams();
+}
+
+// ------------------------------
+void R3BSofTrimCalculateDriftTimeOffsetPar::CalculateOffsets()
+{
+  LOG(INFO) << "R3BSofTrimCalculateDriftTimeOffsetPar: CalculateOffsets()";
+
+  Double_t BinMax, X_BinMax;
+  TF1** fit_max = new TF1*[fNumSections*fNumAnodes]; 
+
+  for(Int_t section=0; section<fNumSections; section++){
+    for(Int_t anode=0; anode<fNumAnodes; anode++){
+      if(fh1_DeltaDT[anode+section*fNumAnodes]->Integral()>fMinStatistics){
+	BinMax = fh1_DeltaDT[anode+section*fNumAnodes]->GetMaximumBin();
+	X_BinMax = fh1_DeltaDT[anode+section*fNumAnodes]->GetBinCenter(BinMax);
+	fit_max[anode+section*fNumAnodes] = new TF1("fit_gaus","gaus",X_BinMax-500,X_BinMax+500);
+	fh1_DeltaDT[anode+section*fNumAnodes]->Fit(fit_max[anode+section*fNumAnodes],"R");
+	fCalPar->SetDriftTimeOffset(section+1,anode+1,fit_max[anode+section*fNumAnodes]->GetParameter(1));
+      }
+    }
+  }
+
+  fCalPar->setChanged();
+  return;
+}
+
+ClassImp(R3BSofTrimCalculateDriftTimeOffsetPar)

--- a/trim/R3BSofTrimCalculateDriftTimeOffsetPar.h
+++ b/trim/R3BSofTrimCalculateDriftTimeOffsetPar.h
@@ -1,0 +1,110 @@
+#ifndef __R3BSOFTRIMDTOFFSETPAR_H__
+#define __R3BSOFTRIMDTOFFSETPAR_H__
+
+#include "FairTask.h"
+
+#include "TH1.h"
+
+class TClonesArray;
+class R3BSofTrimCalPar;
+class R3BEventHeader;
+
+class R3BSofTrimCalculateDriftTimeOffsetPar : public FairTask
+{
+
+  public:
+    /** Default constructor **/
+    R3BSofTrimCalculateDriftTimeOffsetPar();
+
+    /** Standard constructor **/
+    R3BSofTrimCalculateDriftTimeOffsetPar(const char* name, Int_t iVerbose = 1);
+
+    /** Destructor **/
+    virtual ~R3BSofTrimCalculateDriftTimeOffsetPar();
+
+    /** Virtual method Init **/
+    virtual InitStatus Init();
+
+    /** Virtual method Exec **/
+    virtual void Exec(Option_t* opt);
+
+    /** Virtual method FinishEvent **/
+    virtual void FinishEvent();
+
+    /** Virtual method FinishTask **/
+    virtual void FinishTask();
+
+    /** Virtual method Reset **/
+    virtual void Reset();
+
+    /** Virtual method ReInit **/
+    virtual InitStatus ReInit();
+
+    /** Virtual method calculate the gain matching of both anodes  **/
+    virtual void CalculateOffsets();
+
+    void SetOutputFile(const char* outFile);
+
+    /** Accessor functions **/
+    const Int_t GetNumSections()     { return fNumSections; }
+    const Int_t GetNumAnodes()       { return fNumAnodes; }
+    const Int_t GetMinStatistics()   { return fMinStatistics; }
+
+    const Float_t GetMwpc0OffsetX() { return fMwpc0OffsetX;}
+    const Float_t GetMwpc1OffsetX() { return fMwpc1OffsetX;}
+
+    const Float_t GetDistMwpc0Anode1() { return fDistMwpc0Anode1; }
+    const Float_t GetDistMwpc0Mwpc1()  { return fDistMwpc0Mwpc1; }
+
+    const Float_t GetWidthAnode()       { return fWidthAnode;}
+    const Float_t GetDistInterSection() { return fDistInterSection;}
+    const Float_t GetDriftVelocity()    { return fDriftVelocity; }
+
+
+    void SetNumSections(Int_t n) { fNumSections = n; }
+    void SetNumAnodes(Int_t n)   { fNumAnodes  = n; }
+    void SetMinStatistics(Int_t minstat) { fMinStatistics = minstat; }
+
+    void SetMwpc0OffsetX (Float_t offset) { fMwpc0OffsetX = offset; }
+    void SetMwpc1OffsetX (Float_t offset) { fMwpc1OffsetX = offset; }
+
+    void SetDistMwpc0Anode1(Float_t d) { fDistMwpc0Anode1 = d; }
+    void SetDistMwpc0Mwpc1(Float_t d)  { fDistMwpc0Mwpc1 = d; }
+
+    void SetWidthAnode(Float_t w)       { fWidthAnode = w; }
+    void SetDistInterSection(Float_t d) { fDistInterSection = d; }
+    void SetDriftVelocity (Float_t v)   { fDriftVelocity = v; }
+
+  protected:
+    Int_t fNumSections;    
+    Int_t fNumAnodes;      
+    Int_t fMinStatistics;    // minimum statistics to proceed to the calibration
+
+    Float_t fMwpc0OffsetX;
+    Float_t fMwpc1OffsetX;
+
+    Float_t fDistMwpc0Anode1;
+    Float_t fDistMwpc0Mwpc1;
+    Float_t fWidthAnode;
+    Float_t fDistInterSection;
+    Float_t fDriftVelocity;
+
+    // calibration parameters
+    R3BSofTrimCalPar* fCalPar;
+
+    // input data
+    TClonesArray* fTrimCalData;
+    TClonesArray* fMwpc0HitData;
+    TClonesArray* fMwpc1HitData;
+
+    // histograms
+    TH1D ** fh1_DeltaDT;
+
+
+    char* fOutputFile;
+
+  public:
+    ClassDef(R3BSofTrimCalculateDriftTimeOffsetPar, 0);
+};
+
+#endif //__R3BSOFTRIMDTOFFSETPAR_H__

--- a/trim/R3BSofTrimCalculateMatchGainPar.cxx
+++ b/trim/R3BSofTrimCalculateMatchGainPar.cxx
@@ -1,0 +1,233 @@
+#include "R3BSofTrimCalculateMatchGainPar.h"
+
+#include "R3BSofTrimCalPar.h"
+#include "R3BSofTrimCalData.h"
+
+#include "R3BEventHeader.h"
+
+#include "FairLogger.h"
+#include "FairRootManager.h"
+#include "FairRunAna.h"
+#include "FairRuntimeDb.h"
+#include "TGeoManager.h"
+
+#include "TClonesArray.h"
+#include "TGeoMatrix.h"
+#include "TMath.h"
+#include "TObjArray.h"
+#include "TRandom.h"
+#include "TVector3.h"
+
+#include <iostream>
+#include <stdlib.h>
+
+
+// R3BSofTrimCalculateMatchGainPar: Default Constructor --------------------------
+R3BSofTrimCalculateMatchGainPar::R3BSofTrimCalculateMatchGainPar()
+    : FairTask("R3BSofTrimCalculateMatchGainPar", 1)
+    , fNumSections(3)
+    , fNumAnodes(6) 
+    , fMinStatistics(0)
+    , fCalData(NULL)
+    , fCalPar(NULL)
+    , fEpsilon(0.01)
+    , fGainMin(0.8)
+    , fGainMax(1.2)
+    , fOutputFile(NULL)
+{
+  fNumPairsPerSection = fNumAnodes/2;
+  fNumHistosPerPair = (Int_t)((fGainMax-fGainMin)/fEpsilon);
+}
+
+// R3BSofTrimCalculateMatchGainPar: Standard Constructor --------------------------
+R3BSofTrimCalculateMatchGainPar::R3BSofTrimCalculateMatchGainPar(const char* name, Int_t iVerbose)
+    : FairTask(name, iVerbose)
+    , fNumSections(0)
+    , fNumAnodes(0) 
+    , fMinStatistics(0)
+    , fCalData(NULL)
+    , fCalPar(NULL)
+    , fEpsilon(0.01)
+    , fGainMin(0.8)
+    , fGainMax(1.2)
+    , fOutputFile(NULL)
+{
+  fNumPairsPerSection = fNumAnodes / 2;
+  fNumHistosPerPair = (Int_t)((fGainMax-fGainMin)/fEpsilon);
+}
+
+// R3BSofTrimCalculateMatchGainPar: Destructor ----------------------------------------
+R3BSofTrimCalculateMatchGainPar::~R3BSofTrimCalculateMatchGainPar()
+{
+  if (fCalPar)        delete fCalPar;
+}
+
+// -----   Public method Init   --------------------------------------------
+InitStatus R3BSofTrimCalculateMatchGainPar::Init()
+{
+
+    LOG(INFO) << "R3BSofTrimCalculateMatchGainPar: Init";
+
+    FairRootManager* rm = FairRootManager::Instance();
+    if (!rm){
+      return kFATAL;
+    }
+
+    // --- ----------------- --- //
+    // --- INPUT MAPPED DATA --- //
+    // --- ------------------ --- //
+
+    fCalData = (TClonesArray*)rm->GetObject("TrimCalData");
+    if (!fCalData){
+      LOG(ERROR) << "R3BSofTrimCalculateMatchGainPar::Init() Couldn't get handle on TrimCalData";
+      return kFATAL;
+    }
+
+    // --- ------------------------------------------ --- //
+    // --- SOF TRIM TRIANGLE CAL PARAMETERS CONTAINER --- //
+    // --- ------------------------------------------ --- //
+
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    if (!rtdb){
+      return kFATAL;
+    }
+
+    fCalPar = (R3BSofTrimCalPar*)rtdb->getContainer("trimCalPar");
+    if (!fCalPar){
+      LOG(ERROR) << "R3BSofTrimCalculateMatchGainPar::Init() Couldn't get handle on trimCalPar container";
+      return kFATAL;
+    }
+    else{
+      fNumSections = fCalPar->GetNumSections();
+      fNumAnodes = fCalPar->GetNumAnodes();    
+      LOG(INFO) << "R3BSofTrimCalculateMatchGainPar::Init() trimCalPar container found with fNumSections = " << fNumSections;
+    }
+
+    // --- ---------------------- --- //
+    // --- HISTOGRAMS DECLARATION --- //
+    // --- ---------------------- --- //
+
+    char name[100];
+    fh2_TrimPerPair_Esub_vs_Y = new TH2D*[fNumSections*fNumPairsPerSection*fNumHistosPerPair];
+    for (Int_t sec = 0; sec < fNumSections; sec++){
+      for (Int_t pair = 0; pair < (fNumAnodes/2); pair++){
+	for (Int_t k=0; k<fNumHistosPerPair; k++){
+	  sprintf(name, "Trim_Esub_vs_Y_Sec%i_Pair%i_k%i", sec+1, pair+1, k+1);
+	  fh2_TrimPerPair_Esub_vs_Y[k + pair*fNumHistosPerPair + sec*fNumHistosPerPair*fNumAnodes/2] = new TH2D(name, name, 1600,-0.4,0.4,1000,0,20000);
+	  fh2_TrimPerPair_Esub_vs_Y[k + pair*fNumHistosPerPair + sec*fNumHistosPerPair*fNumAnodes/2]->GetXaxis()->SetTitle("Ratio between EsubDiff and EsubSum <=> Y [channels]");
+	  fh2_TrimPerPair_Esub_vs_Y[k + pair*fNumHistosPerPair + sec*fNumHistosPerPair*fNumAnodes/2]->GetYaxis()->SetTitle("EsubSum [channels]");
+	}
+      }
+    }
+
+    return kSUCCESS;
+}
+
+// -----   Public method ReInit  --------------------------------------------
+InitStatus R3BSofTrimCalculateMatchGainPar::ReInit() { return kSUCCESS; }
+
+// -----   Public method Exec   --------------------------------------------
+void R3BSofTrimCalculateMatchGainPar::Exec(Option_t* opt)
+{
+
+  Int_t iSec,iAnode,iPair;
+  Float_t EsubDown[fNumSections*fNumPairsPerSection];
+  Float_t EsubUp[fNumSections*fNumPairsPerSection];
+  UInt_t  mult[fNumSections*fNumAnodes];
+  Double_t Esum, Ediff, gain_match_local;
+
+  for(UShort_t anode=0; anode<fNumSections*fNumAnodes; anode++) mult[anode]=0;
+
+  // --- ------------------------------ --- //
+  // --- LOOP OVER CAL DATA FOR SofTrim --- //
+  // --- ------------------------------ --- //
+  UInt_t nHits = fCalData->GetEntries(); 
+  if (!nHits) return;
+  for(Int_t ihit=0; ihit<nHits; ihit++){
+    R3BSofTrimCalData* hit = (R3BSofTrimCalData*)fCalData->At(ihit);
+    iSec = hit->GetSecID()-1; 
+    iAnode = hit->GetAnodeID()-1;
+    mult[iAnode+iSec*fNumAnodes]++;
+  }// end of loop over the cal data
+
+  // --- --------------------------------------------- --- //
+  // --- FILL THE HISTOGRAMS WITH CLEAN DATA (mult==1) --- //
+  // --- --------------------------------------------- --- //
+  for(Int_t section=0; section<fNumSections; section++){
+    for(Int_t pair=0; pair<fNumPairsPerSection; pair++){
+      if( (mult[pair*2+section*fNumAnodes]==mult[pair*2+1+section*fNumAnodes]) && (mult[pair*2+section*fNumAnodes]==1) ){
+	for(Int_t k=0; k<fNumHistosPerPair; k++){
+	  gain_match_local = (Double_t)fGainMin + (Double_t)k*(Double_t)fEpsilon;
+	  Esum  = (Double_t)EsubUp[pair+section*fNumPairsPerSection] + gain_match_local*EsubDown[pair+section*fNumPairsPerSection];
+	  Ediff = (Double_t)EsubUp[pair+section*fNumPairsPerSection] - gain_match_local*EsubDown[pair+section*fNumPairsPerSection];
+	  if(Esum!=0)
+	    fh2_TrimPerPair_Esub_vs_Y[k + pair*fNumHistosPerPair + section*fNumHistosPerPair*fNumPairsPerSection]->Fill(Ediff/Esum,Esum);
+	}
+      }// end of check mult up = mult down
+    }//end of loop over the pairs
+  }// end of loop over the sections
+}
+
+// ---- Public method Reset   --------------------------------------------------
+void R3BSofTrimCalculateMatchGainPar::Reset() {}
+
+void R3BSofTrimCalculateMatchGainPar::FinishEvent() {}
+
+// ---- Public method Finish   --------------------------------------------------
+void R3BSofTrimCalculateMatchGainPar::FinishTask()
+{
+   PlotEvsY();
+   fCalPar->printParams();
+}
+
+// ------------------------------
+void R3BSofTrimCalculateMatchGainPar::PlotEvsY()
+{
+  LOG(INFO) << "R3BSofTrimCalculateMatchGainPar: CalculateGainMatchingParams()";
+  char name[100];
+  TH1D** h1_ProjectionY = new TH1D*[fNumSections*fNumPairsPerSection*fNumHistosPerPair];
+  TF1** fit_max = new TF1*[fNumSections*fNumPairsPerSection*fNumHistosPerPair]; 
+  Double_t Bmax, Xmax,Sigma,Min;
+  TGraph ** gr = new TGraph*[fNumSections*fNumPairsPerSection];
+  for(Int_t section=0; section<fNumSections; section++){
+    for(Int_t pair=0; pair<fNumPairsPerSection; pair++){
+      sprintf(name,"Sigma_S%iP%i",section+1,pair+1);
+      gr[pair+section*fNumPairsPerSection] = new TGraph();
+      gr[pair+section*fNumPairsPerSection]->SetName(name);
+      gr[pair+section*fNumPairsPerSection]->SetTitle(name);
+      Min=1000.;
+      for(Int_t k=0; k<fNumHistosPerPair; k++){
+	if (fh2_TrimPerPair_Esub_vs_Y[k + pair*fNumHistosPerPair + section*fNumHistosPerPair*fNumPairsPerSection]->Integral()>0){
+
+	  fh2_TrimPerPair_Esub_vs_Y[k + pair*fNumHistosPerPair + section*fNumHistosPerPair*fNumPairsPerSection]->Write();	
+	  sprintf(name,"EvsY_S%iP%i_k%f_pjY",section+1,pair+1,(Double_t)fGainMin + (Double_t)k*(Double_t)fEpsilon);
+	  fh2_TrimPerPair_Esub_vs_Y[k + pair*fNumHistosPerPair + section*fNumHistosPerPair*fNumPairsPerSection]->ProjectionY(name);
+
+	  h1_ProjectionY[k + pair*fNumHistosPerPair + section*fNumHistosPerPair*fNumPairsPerSection]=(TH1D*)gDirectory->FindObject(name);
+	  h1_ProjectionY[k + pair*fNumHistosPerPair + section*fNumHistosPerPair*fNumPairsPerSection]->Write();
+
+	  Bmax =  h1_ProjectionY[k + pair*fNumHistosPerPair + section*fNumHistosPerPair*fNumPairsPerSection]->GetMaximumBin();
+	  Xmax =  h1_ProjectionY[k + pair*fNumHistosPerPair + section*fNumHistosPerPair*fNumPairsPerSection]->GetBinCenter(Bmax);
+	  fit_max[k + pair*fNumHistosPerPair + section*fNumHistosPerPair*fNumPairsPerSection] = new TF1("fit_gaus","gaus",Xmax-200,Xmax+200);
+	  h1_ProjectionY[k + pair*fNumHistosPerPair + section*fNumHistosPerPair*fNumPairsPerSection]->Fit(fit_max[k + pair*fNumHistosPerPair + section*fNumHistosPerPair*fNumPairsPerSection],"R");
+	  fit_max[k + pair*fNumHistosPerPair + section*fNumHistosPerPair*fNumPairsPerSection]->Write();
+	  Sigma = fit_max[k + pair*fNumHistosPerPair + section*fNumHistosPerPair*fNumPairsPerSection]->GetParameter(2);
+	  if(Sigma<Min) {
+	    Min=Sigma;
+	    fCalPar->SetEnergyMatchGain((Double_t)fGainMin + (Double_t)k*(Double_t)fEpsilon,section+1,(2*pair)+1);
+	    fCalPar->SetEnergyMatchGain(1.,section+1,(2*pair)+2);
+	  }
+	  gr[pair+section*fNumPairsPerSection]->SetPoint(k,(Double_t)fGainMin + (Double_t)k*(Double_t)fEpsilon,Sigma);
+	}
+      }
+      if(gr[pair+section*fNumPairsPerSection]->GetN()>0){
+	gr[pair+section*fNumPairsPerSection]->Write();
+      }
+    }
+  }
+
+  fCalPar->setChanged();
+  return;
+}
+
+ClassImp(R3BSofTrimCalculateMatchGainPar)

--- a/trim/R3BSofTrimCalculateMatchGainPar.h
+++ b/trim/R3BSofTrimCalculateMatchGainPar.h
@@ -1,0 +1,96 @@
+#ifndef __R3BSOFTRIMMATCHGAINPAR_H__
+#define __R3BSOFTRIMMATCHGAINPAR_H__
+
+#include "FairTask.h"
+#include "TF1.h"
+#include "TGraph.h"
+#include "TH1D.h"
+#include "TH2D.h"
+
+class TClonesArray;
+class R3BSofTrimCalPar;
+class R3BEventHeader;
+
+class R3BSofTrimCalculateMatchGainPar : public FairTask
+{
+
+  public:
+    /** Default constructor **/
+    R3BSofTrimCalculateMatchGainPar();
+
+    /** Standard constructor **/
+    R3BSofTrimCalculateMatchGainPar(const char* name, Int_t iVerbose = 1);
+
+    /** Destructor **/
+    virtual ~R3BSofTrimCalculateMatchGainPar();
+
+    /** Virtual method Init **/
+    virtual InitStatus Init();
+
+    /** Virtual method Exec **/
+    virtual void Exec(Option_t* opt);
+
+    /** Virtual method FinishEvent **/
+    virtual void FinishEvent();
+
+    /** Virtual method FinishTask **/
+    virtual void FinishTask();
+
+    /** Virtual method Reset **/
+    virtual void Reset();
+
+    /** Virtual method ReInit **/
+    virtual InitStatus ReInit();
+
+    /** Virtual method calculate the gain matching of both anodes  **/
+    virtual void PlotEvsY();
+
+    void SetOutputFile(const char* outFile);
+
+    /** Accessor functions **/
+    const Int_t GetNumSections()     { return fNumSections; }
+    const Int_t GetNumAnodes()       { return fNumAnodes; }
+    const Int_t GetNumPairsPerSection() { return fNumPairsPerSection; }
+    const Int_t GetMinStatistics()   { return fMinStatistics; }
+
+    const Float_t GetEpsilon() { return fEpsilon;}
+    const Float_t GetGainMin() { return fGainMin;}
+    const Float_t GetGainMax() { return fGainMax;}
+
+    void SetNumSections(Int_t n) { fNumSections = n; }
+    void SetNumAnodes(Int_t n)   { fNumAnodes  = n;}
+    void SetNumPairsPerSection()         { fNumPairsPerSection = fNumAnodes / 2;}
+    void SetMinStatistics(Int_t minstat) { fMinStatistics = minstat; }
+
+    void SetEpsilon(Float_t epsilon) {fEpsilon = epsilon;}
+    void SetGainMin(Float_t gain)    {fGainMin=gain;}
+    void SetGainMax(Float_t gain)    {fGainMax=gain;}
+    void SetNumHistosPerPair(Float_t gain_min, Float_t gain_max, Float_t epsilon) {
+      fNumHistosPerPair = (Int_t)((fGainMax-fGainMin)/fEpsilon);
+    }
+
+  protected:
+    Int_t fNumSections;    
+    Int_t fNumAnodes;      
+    Int_t fNumPairsPerSection;
+    Int_t fNumHistosPerPair;
+    Int_t fMinStatistics;    // minimum statistics to proceed to the calibration
+
+    // calibration parameters
+    R3BSofTrimCalPar* fCalPar;
+
+    // input data
+    TClonesArray* fCalData;
+
+    // histograms
+    TH2D** fh2_TrimPerPair_Esub_vs_Y;
+    Float_t fEpsilon;
+    Float_t fGainMin;
+    Float_t fGainMax;
+    char* fOutputFile;
+
+  public:
+    ClassDef(R3BSofTrimCalculateMatchGainPar, 0);
+};
+
+#endif //__R3BSOFTRIMMATCHGAINPAR_H__

--- a/trim/R3BSofTrimContFact.cxx
+++ b/trim/R3BSofTrimContFact.cxx
@@ -1,0 +1,76 @@
+// --------------------------------------------------------------------
+// -----          R3BSofTrimContFact source file                  -----
+// --------------------------------------------------------------------
+//
+//  R3BSofTrimContFact
+//
+//  Factory for the parameter containers in libR3BSofTrim
+//
+
+#include "R3BSofTrimContFact.h"
+
+#include "FairLogger.h"
+#include "FairParAsciiFileIo.h"
+#include "FairParRootFileIo.h"
+#include "FairRuntimeDb.h"
+
+#include "R3BSofTrimCalPar.h"
+
+#include "TClass.h"
+
+static R3BSofTrimContFact gR3BSofTrimContFact;
+
+R3BSofTrimContFact::R3BSofTrimContFact()
+{
+    // Constructor (called when the library is loaded)
+    fName = "R3BSofTrimContFact";
+    fTitle = "Factory for parameter containers in libR3BSofTrim";
+    setAllContainers();
+    FairRuntimeDb::instance()->addContFactory(this);
+}
+
+void R3BSofTrimContFact::setAllContainers()
+{
+    // Creates the Container objects with all accepted contexts and adds them to
+    // the list of containers for the STS library.
+
+    FairContainer* p1 = new FairContainer("trimCalPar", "Triple MUSIC Cal Parameters", "TrimCalParContext");
+    p1->addContext("TrimCalParContext");
+
+    containers->Add(p1);
+
+}
+
+FairParSet* R3BSofTrimContFact::createContainer(FairContainer* c)
+{
+    // Trals the constructor of the corresponding parameter container.
+    // For an actual context, which is not an empty string and not the default context
+    // of this container, the name is concatinated with the context.
+
+    const char* name = c->GetName();
+    LOG(INFO) << "R3BSofTrimContFact: Create container name: " << name;
+    FairParSet* p = 0;
+    if (strcmp(name, "trimCalPar") == 0)
+    {
+        p = new R3BSofTrimCalPar(c->getConcatName().Data(), c->GetTitle(), c->getContext());
+    }
+    return p;
+}
+
+void R3BSofTrimContFact::activateParIo(FairParIo* io)
+{
+    // activates the input/output class for the parameters
+    // needed by the Trim
+    /*
+    if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
+      R3BSofTrimParRootFileIo* p=new R3BSofTrimParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      io->setDetParIo(p);
+    }
+    if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
+      R3BSofTrimParAsciiFileIo* p=new R3BSofTrimParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      io->setDetParIo(p);
+      }
+    */
+}
+
+ClassImp(R3BSofTrimContFact)

--- a/trim/R3BSofTrimContFact.h
+++ b/trim/R3BSofTrimContFact.h
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------
+// -----             R3BSofTrimContFact source file             -----
+// ------------------------------------------------------------------
+
+#ifndef R3BSofTrimContFact_H
+#define R3BSofTrimContFact_H
+
+#include "FairContFact.h"
+
+class FairContainer;
+
+class R3BSofTrimContFact : public FairContFact
+{
+  private:
+    void setAllContainers();
+
+  public:
+    R3BSofTrimContFact();
+    ~R3BSofTrimContFact() {}
+    FairParSet* createContainer(FairContainer*);
+    void activateParIo(FairParIo* io);
+    ClassDef(R3BSofTrimContFact, 0) // Factory for all R3BSofTrim parameter containers
+};
+
+#endif /* R3BSofTrimContFact_H */

--- a/trim/R3BSofTrimMapped2Cal.cxx
+++ b/trim/R3BSofTrimMapped2Cal.cxx
@@ -1,0 +1,204 @@
+// ------------------------------------------------------------
+// -----         R3BSofTrimMapped2Cal source file         -----
+// ------------------------------------------------------------
+
+// ROOT headers
+#include "TClonesArray.h"
+#include "TMath.h"
+#include "TRandom.h"
+
+// Fair headers
+#include "FairLogger.h"
+#include "FairRootManager.h"
+#include "FairRunAna.h"
+#include "FairRuntimeDb.h"
+
+#include <iomanip>
+
+// Trim headers
+#include "R3BSofTrimMappedData.h"
+#include "R3BSofTrimCalData.h"
+#include "R3BSofTrimCalPar.h"
+#include "R3BSofTrimMapped2Cal.h"
+
+// R3BSofTrimMapped2Cal: Default Constructor --------------------------
+R3BSofTrimMapped2Cal::R3BSofTrimMapped2Cal()
+    : FairTask("R3BSof Trim Cal Calibrator", 1)
+    , fCal_Par(NULL)
+    , fTrimMappedDataCA(NULL)
+    , fTrimCalDataCA(NULL)
+    , fOnline(kFALSE)
+    , fNumSections(3)
+    , fNumAnodes(6)
+{
+  fNumChannels = fNumAnodes + 2; // anodes + Tref + Ttrig
+}
+
+// R3BSofTrimMapped2CalPar: Standard Constructor --------------------------
+R3BSofTrimMapped2Cal::R3BSofTrimMapped2Cal(const char* name, Int_t iVerbose)
+    : FairTask(name, iVerbose)
+    , fCal_Par(NULL)
+    , fTrimMappedDataCA(NULL)
+    , fTrimCalDataCA(NULL)
+    , fOnline(kFALSE)
+    , fNumSections(3)
+    , fNumAnodes(6)
+{
+  fNumChannels = fNumAnodes + 2; // anodes + Tref + Ttrig
+}
+
+// Virtual R3BSofTrimMapped2Cal: Destructor
+R3BSofTrimMapped2Cal::~R3BSofTrimMapped2Cal()
+{
+    LOG(INFO) << "R3BSofTrimMapped2Cal: Delete instance";
+    if (fTrimMappedDataCA)  delete fTrimMappedDataCA;
+    if (fTrimCalDataCA)     delete fTrimCalDataCA;
+}
+
+void R3BSofTrimMapped2Cal::SetParContainers()
+{
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    if (!rtdb){
+      LOG(ERROR) << "FairRuntimeDb not opened!";
+    }
+
+    fCal_Par = (R3BSofTrimCalPar*)rtdb->getContainer("trimCalPar");
+    if (!fCal_Par){
+      LOG(ERROR) << "R3BSofTrimMapped2CalPar::Init() Couldn't get handle on trimCalPar container";
+      return;
+    }
+    else{
+      if (fNumSections != fCal_Par->GetNumSections()) 
+	LOG(INFO) << "R3BSofTrimMapped2CalPar::Init() fNumSections=" << fNumSections << " different from parameter " << fCal_Par->GetNumSections();
+      if (fNumAnodes != fCal_Par->GetNumAnodes())
+	LOG(INFO) << "R3BSofTrimMapped2CalPar::Init() fNumAnodes=" << fNumAnodes << " different from parameter " << fCal_Par->GetNumAnodes();
+      LOG(INFO) << "R3BSofTrimMapped2CalPar:: trimCalPar container open";
+    }
+}
+
+// -----   Public method Init   --------------------------------------------
+InitStatus R3BSofTrimMapped2Cal::Init()
+{
+    LOG(INFO) << "R3BSofTrimMapped2Cal: Init";
+
+    // --- ----------------- --- //
+    // --- INPUT MAPPED DATA --- //
+    // --- ----------------- --- //
+    FairRootManager* rootManager = FairRootManager::Instance();
+    if (!rootManager){
+        return kFATAL;
+    }
+
+    fTrimMappedDataCA = (TClonesArray*)rootManager->GetObject("TrimMappedData");
+    if (!fTrimMappedDataCA){
+      return kFATAL;
+    }
+    
+    // --- ------------------------ --- //
+    // --- OUTPUT TRIANGLE CAL DATA --- //
+    // --- ------------------------ --- //
+    fTrimCalDataCA = new TClonesArray("R3BSofTrimCalData", MAX_MULT_TRIM_CAL * 8);
+
+    if (!fOnline){
+      rootManager->Register("TrimCalData", "Trim Cal", fTrimCalDataCA, kTRUE);
+    }
+    else{
+      rootManager->Register("TrimCalData", "Trim Cal", fTrimCalDataCA, kFALSE);
+    }
+    
+    return kSUCCESS;
+}
+
+// -----   Public method ReInit   ----------------------------------------------
+InitStatus R3BSofTrimMapped2Cal::ReInit()
+{
+    SetParContainers();
+    return kSUCCESS;
+}
+
+// -----   Public method Execution   --------------------------------------------
+void R3BSofTrimMapped2Cal::Exec(Option_t* option)
+{
+    // Reset entries in output arrays, local arrays
+    Reset();
+
+    // get the parameters
+    if (!fCal_Par){
+      LOG(ERROR) << "R3BSofTrimMapped2Cal: NOT Container Parameter!!";
+    }
+
+    // Reading input mapped data per anode
+    //   --> number of channels = number of anodes (6: id=1..6) + number of Tref (1: id=fNumAnodes+1) + number of Ttrig (1: id=fNumAnodes+2)
+    Int_t nHits = fTrimMappedDataCA->GetEntries();
+    if (!nHits) return;
+    // FIX ME TO BE MOVED TO Init()
+    UInt_t mult[fNumSections*fNumChannels]; 
+    UShort_t iTraw[fNumSections*fNumChannels][MAX_MULT_TRIM_CAL];
+    UShort_t iEraw[fNumSections*fNumChannels][MAX_MULT_TRIM_CAL];
+    Int_t iSec;
+    Int_t iCh;
+    for(UInt_t sec=0; sec<fNumSections; sec++){
+      for(UInt_t a=0; a<fNumChannels; a++){
+	mult[a+fNumChannels*sec]=0;
+	for(UShort_t m=0; m<MAX_MULT_TRIM_CAL;m++){
+	  iTraw[a+fNumChannels*sec][m]=0;
+	  iEraw[a+fNumChannels*sec][m]=0;
+	}
+      }
+    }
+
+    for(Int_t ihit=0; ihit<nHits; ihit++){
+      R3BSofTrimMappedData* hit = (R3BSofTrimMappedData*)fTrimMappedDataCA->At(ihit);
+      if(hit->GetPileupStatus() || hit->GetOverflowStatus() ) continue;
+      iSec = hit->GetSecID()-1; 
+      iCh  = hit->GetAnodeID()-1;
+      if(mult[iCh + fNumChannels*iSec]>MAX_MULT_TRIM_CAL) continue;
+      iTraw[iCh + fNumChannels*iSec][mult[iCh + fNumChannels*iSec]] = hit->GetTime();
+      iEraw[iCh + fNumChannels*iSec][mult[iCh + fNumChannels*iSec]] = hit->GetEnergy();
+      mult[iCh + fNumChannels*iSec]++;
+    }// end of loop over the mapped data
+
+    // Fill data only if there is a unique TREF signal
+    Double_t dtraw, dtal;
+    Float_t  esub, ematch, eal;
+    for (Int_t s = 0; s < fNumSections; s++){
+      if(mult[fNumAnodes+fNumChannels*s]==1){
+	for(Int_t a=0; a<fNumAnodes;a++){
+	  if(mult[a+fNumChannels*s]>0){
+	    for(Int_t i=0; i<mult[a+fNumChannels*s]; i++){
+	      dtraw = (Double_t)iTraw[a+fNumChannels*s][i]-(Double_t)iTraw[fNumAnodes+fNumChannels*s][0];
+	      dtal   = dtraw + fCal_Par->GetDriftTimeOffset(s+1,a+1); 
+	      esub   = (Float_t)iEraw[a+fNumChannels*s][i] - fCal_Par->GetEnergyPedestal(s+1,a+1);
+	      ematch = esub*fCal_Par->GetEnergyMatchGain(s+1,a+1);
+	      AddCalData(s+1, a+1, dtraw, dtal, esub, ematch);
+	    }
+	  }// end of check that anode has data
+	}// end of loop over the anodes 
+      }// end of one Tref per Section
+    }// end of loop over section
+    
+    return;
+}
+
+// -----   Protected method Finish   --------------------------------------------
+void R3BSofTrimMapped2Cal::Finish() {}
+
+// -----   Public method Reset   ------------------------------------------------
+void R3BSofTrimMapped2Cal::Reset()
+{
+    LOG(DEBUG) << "Clearing TrimCalData Structure";
+    if (fTrimCalDataCA) fTrimCalDataCA->Clear();
+}
+
+// -----   Private method AddCalData  --------------------------------------------
+R3BSofTrimCalData* R3BSofTrimMapped2Cal::AddCalData(Int_t secID,    Int_t anodeID, 
+						    Double_t dtraw, Double_t dtal,
+						    Float_t  esub,  Float_t  ematch)
+{
+    // It fills the R3BSofTrimCalData
+    TClonesArray& clref = *fTrimCalDataCA;
+    Int_t size = clref.GetEntriesFast();
+    return new (clref[size]) R3BSofTrimCalData(secID, anodeID, dtraw, dtal, esub, ematch);
+}
+
+ClassImp(R3BSofTrimMapped2Cal)

--- a/trim/R3BSofTrimMapped2Cal.h
+++ b/trim/R3BSofTrimMapped2Cal.h
@@ -1,0 +1,73 @@
+// -----------------------------------------------------------------
+// -----                R3BSofTrimMapped2Cal                   -----
+// -----------------------------------------------------------------
+
+#ifndef R3BSofTrimMapped2Cal_H
+#define R3BSofTrimMapped2Cal_H
+
+#include "FairTask.h"
+#include "R3BSofTrimCalData.h"
+#include "R3BSofTrimMappedData.h"
+#include "TH1F.h"
+#include <TRandom.h>
+
+#define MAX_MULT_TRIM_CAL 10
+
+class TClonesArray;
+class R3BSofTrimCalPar;
+
+class R3BSofTrimMapped2Cal : public FairTask
+{
+
+  public:
+    /** Default constructor **/
+    R3BSofTrimMapped2Cal();
+
+    /** Standard constructor **/
+    R3BSofTrimMapped2Cal(const char* name, Int_t iVerbose = 1);
+
+    /** Destructor **/
+    virtual ~R3BSofTrimMapped2Cal();
+
+    /** Virtual method Exec **/
+    virtual void Exec(Option_t* option);
+
+    /** Virtual method Reset **/
+    virtual void Reset();
+
+    virtual void SetParContainers();
+
+    // Fair specific
+    /** Virtual method Init **/
+    virtual InitStatus Init();
+
+    /** Virtual method ReInit **/
+    virtual InitStatus ReInit();
+
+    /** Virtual method Finish **/
+    virtual void Finish();
+
+    void SetOnline(Bool_t option) { fOnline = option; }
+
+  private:
+    Bool_t fOnline; // Don't store data for online
+
+    R3BSofTrimCalPar*  fCal_Par;             /**< Parameter container. >*/
+    TClonesArray* fTrimMappedDataCA;         /**< Array with Mapped-input data. >*/
+    TClonesArray* fTrimCalDataCA;            /**< Array with Cal-output data. >*/
+
+    Int_t  fNumSections;
+    Int_t  fNumAnodes;
+    Int_t  fNumChannels;
+
+    /** Private method AddCalData **/
+    R3BSofTrimCalData* AddCalData(Int_t    secID,   Int_t    anodeID, 
+				  Double_t dtraw,   Double_t dtal, 
+				  Float_t  esub,    Float_t  ematch);
+
+  public:
+    // Class definition
+    ClassDef(R3BSofTrimMapped2Cal, 1)
+};
+
+#endif

--- a/trim/README.md
+++ b/trim/README.md
@@ -1,0 +1,92 @@
+# Triple-MUSIC
+
+Today (May 2020), due to the COVID-19 pandemia, the refurbishment of the Triple-MUSIC is still pending.
+Therefore, the analysis is developped in order to deal either with the "triangular" shape anodes or with the "rectangular" shape anodes.
+Only some calibration parameters will remain to 0 or 1 default value, in case of triangular shape.
+
+# Geometry
+
+For the triangular shape, each section has 3 pairs of anodes, each pair is made of 2 right-angled triangle: one up and one down.
+For the rectangular shape, each section has 6 rectangular anodes.
+
+# Calibration of the drift time: from Mapped to Cal 
+
+This step is the same wether we deal with triangular or rectangular shape.
+at the begining the calibration parameters of the drift time are given with default values in CalibParams.par
+
+trimDriftTimeOffsets:  Double_t \
+  0. 0. 0. 0. 0. 0.  \
+  0. 0. 0. 0. 0. 0.  \
+  0. 0. 0. 0. 0. 0. 
+
+
+### Step 1: calculation of raw drift time per anode: DTraw
+* This is the first step in Mapped2Cal class
+
+### Step 2: alignment of the drift time per anode: DTalign
+* This offset is obtained from the difference of drift time between the raw measured drift-time in Triple-MUSIC and the reconstructed drift-time inferred from the tracking between MWPC0 and MWPC1. 
+* IMPORTANT: For this calibration, the input data should be a run with primary beam [no fragments] and an empty target.
+* Since the DTraw is calculated in Mapped2Cal, the calculation of the trimDriftTimeOffset take as input SofTrimCalData, and of course the Hit level of the Mwpc0 and Mwpc1 data
+* In the R3BSofTrimCalculateDriftTimeOffset, the theoretical value of the drift velocity is actually used.
+We need to check if this should be changed to a more "real" drift velocity, which would need to be calibrated before.
+
+# Calibration of the energy loss: from Mapped to Cal
+
+at the begining the calibration parameters of the energy loss are given with default values in CalibParams.par
+
+trimEnergyPedestals: Float_t \
+  0. 0. 0. 0. 0. 0.  \
+  0. 0. 0. 0. 0. 0.  \
+  0. 0. 0. 0. 0. 0. 
+trimEnergyMatchGains: Float_t \
+  1. 1. 1. 1. 1. 1.  \
+  1. 1. 1. 1. 1. 1.  \
+  1. 1. 1. 1. 1. 1.
+
+### Step 1: subtraction of the pedestal for the raw energy of each anode Esub
+* All parameters of the MDPP16 should be adjusted first: gain, shaping-time, integration/differention, etc...
+* Once this is is done and without beam, put the threshold to zero and trig the DAQ with pulser.
+* Look at the raw data, and fit the pedestal.
+* Replace the value in the CalibParams.par
+
+trimEnergyPedestals: Float_t \
+  val_S1_A1 val_S1_A2 val_S1_A3 val_S1_A4 val_S1_A5 val_S1_A6  \
+  val_S2_A1 val_S2_A2 val_S2_A3 val_S2_A4 val_S2_A5 val_S2_A6  \
+  val_S3_A1 val_S3_A2 val_S3_A3 val_S3_A4 val_S3_A5 val_S3_A6
+
+This subtraction is negligible with MDPP16, if it is not possible to do it, it won't harm.
+In the latter case, let the parameters for the pedestal to 0.
+
+### Step 2: gain matching of the energy losses Esub for the two triangular anodes in a pair : Ematch
+* This step is only mandatory for the triangular shape.
+For rectangular shape, the calibration parameters trimEnergyMatchGains will remain to 1.
+For the triangular shape, the calibration parameters correspond to a gain for the "down" anode, therefore the calibration parameter for the up anode is always equal to 1
+* Since the Esub is calculated in Mapped2Cal, the calculation of the trimEnergyMatchGains take as input SofTrimCalData.
+
+# Calibration of the energy loss: from Cal to Hit
+
+### Step 1: alignement of the energy loss on primary beam : Ealign and calculation of the energy loss per section Eraw_sum
+* This step is slightly different for rectangular or triangular anodes.
+* For the rectangular anode, each anode is aligned to the same channel, whereas for the triangular anode, the sum of Ealign per pair is aligned to the same channel. This sum will be assigned to the first anode (down) therefore the value for the second anode (up) will be assigned to 0.
+* Since the Ematch is calculated in Mapped2Cal, the calculation of the trimEnergyAlignGains take as input SofTrimCalData.
+* Then, it is quite simple to get the raw energy loss per section : Eraw_sum = Sum_i {Ealign_i}
+
+In case of rectangular anode shape :
+trimEnergyAlignGains: Float_t \
+  val_S1_A1 val_S1_A2 val_S1_A3 val_S1_A4 val_S1_A5 val_S1_A6  \
+  val_S2_A1 val_S2_A2 val_S2_A3 val_S2_A4 val_S2_A5 val_S2_A6  \
+  val_S3_A1 val_S3_A2 val_S3_A3 val_S3_A4 val_S3_A5 val_S3_A6
+
+In case of triangular anode shape :
+trimEnergyAlignGains: Float_t \
+  val_S1_P1 0. val_S1_P2 0. val_S1_P3 0.  \
+  val_S2_P1 0. val_S2_P2 0. val_S2_P3 0.  \
+  val_S3_P1 0. val_S3_P2 0. val_S3_P3 0. 
+
+### Step 2: correction from beta: Ecorr_beta
+
+### Step 3: correction from the DT: Ecorr_dt
+
+### Step 4: correction from the theta angle: Ecorr_theta
+
+### Step 5: conversion from energy loss to Z

--- a/trim/SofTrimLinkDef.h
+++ b/trim/SofTrimLinkDef.h
@@ -6,4 +6,11 @@
 
 #pragma link C++ class R3BSofTRIM + ;
 
+#pragma link C++ class R3BSofTrimContFact + ;
+#pragma link C++ class R3BSofTrimCalPar + ;
+
+#pragma link C++ class R3BSofTrimMapped2Cal + ;
+#pragma link C++ class R3BSofTrimCalculateMatchGainPar + ;
+#pragma link C++ class R3BSofTrimCalculateDriftTimeOffsetPar + ;
+
 #endif


### PR DESCRIPTION
define the work to be done

add arguments to R3BSofTrimTriangleCalData (easier for on-line checking)

add the container and cal parameters for R3BSofTrim

change SecId and AnodeId for Int_t

Fill the TriangleCal level for R3BSofTrim [on-going]

add the cal parameters for energy gain matching and alignement

bug in sofdata/R3BSofDataLinkDef.h typo in the class name

some debugging of  R3BSofTrimMapped2TriangleCal in Exec()

add TriangleCal data online histograms for the Triple-MUSIC

cosmetics

calculation on gain matching between triangular anodes [on-going]

change name of class R3BSofTrimMapped2MatchGainPar -> R3BSofTrimCalculateMatchGainPar

debug R3BSofTrimMapped2TriangleCal::Exec() for esub_u calculation

method to calculate the gain matching between up/down triangular anodes

debug R3BSofTrimCalculateMatchGainPar::PlotEvsY()

change R3BSofTrimTriangleCal to R3BSofTrimCal more user friendly

debugging the TriangleCal -> Cal

debug TrimOnlineSpectra

some simplification of the TrimOnlineSpectra

on-going implementation of R3BSofTrimCalculateDriftTimeOffsetPar

modify CMakeList and LinkDef for the new class

R3BSofTrimCalculateDriftTimeOffsetPar done with fixed fDriftVelocity

move the step Ematch -> Ealign in the Cal2Hit (Ematch (->Ealign) -> Esum_raw)