### PR TITLE
Bug fix of TPAT, Updated RawPos/TofPar of SofSci, Updated SofSciTcal2SingleTcal, Updated Twim

### DIFF
--- a/macros/s444/main_online.C
+++ b/macros/s444/main_online.C
@@ -145,11 +145,6 @@ void main_online()
     source->SetMaxEvents(nev);
 
     // Definition of reader ---------------------------------
-    R3BUnpackReader* unpackreader =
-        new R3BUnpackReader((EXT_STR_h101_unpack*)&ucesb_struct, offsetof(EXT_STR_h101, unpack));
-    R3BTrloiiTpatReader* unpacktpat =
-        new R3BTrloiiTpatReader((EXT_STR_h101_TPAT*)&ucesb_struct, offsetof(EXT_STR_h101, unpacktpat));
-
     R3BFrsReaderNov19* unpackfrs;
     R3BMusicReader* unpackmusic;
     R3BSofSciReader* unpacksci;
@@ -221,8 +216,8 @@ void main_online()
     }
 
     // Add readers ------------------------------------------
-    source->AddReader(unpackreader);
-    source->AddReader(unpacktpat);
+    source->AddReader(new R3BUnpackReader(&ucesb_struct.unpack,offsetof(EXT_STR_h101, unpack)));
+    source->AddReader(new R3BTrloiiTpatReader(&ucesb_struct.unpacktpat,offsetof(EXT_STR_h101, unpacktpat)));
 
     if (fFrsTpcs)
     {

--- a/macros/s467/main_online.C
+++ b/macros/s467/main_online.C
@@ -146,11 +146,6 @@ void main_online()
     source->SetMaxEvents(nev);
 
     // Definition of reader ---------------------------------
-    R3BUnpackReader* unpackreader =
-        new R3BUnpackReader((EXT_STR_h101_unpack*)&ucesb_struct, offsetof(EXT_STR_h101, unpack));
-    R3BTrloiiTpatReader* unpacktpat =
-        new R3BTrloiiTpatReader((EXT_STR_h101_TPAT*)&ucesb_struct, offsetof(EXT_STR_h101, unpacktpat));
-
     R3BFrsReaderNov19* unpackfrs;
     R3BMusicReader* unpackmusic;
     R3BSofSciReader* unpacksci;
@@ -222,8 +217,8 @@ void main_online()
     }
 
     // Add readers ------------------------------------------
-    source->AddReader(unpackreader);
-    source->AddReader(unpacktpat);
+    source->AddReader(new R3BUnpackReader(&ucesb_struct.unpack,offsetof(EXT_STR_h101, unpack)));
+    source->AddReader(new R3BTrloiiTpatReader(&ucesb_struct.unpacktpat,offsetof(EXT_STR_h101, unpacktpat)));
 
     if (fFrsTpcs)
     {

--- a/sci/R3BSofSciTcal2RawPosPar.h
+++ b/sci/R3BSofSciTcal2RawPosPar.h
@@ -4,6 +4,7 @@
 #include "FairTask.h"
 #include "TH1D.h"
 #include "TH1F.h"
+#include "TF1.h"
 
 class TClonesArray;
 class R3BSofSciRawPosPar;
@@ -77,6 +78,9 @@ class R3BSofSciTcal2RawPosPar : public FairTask
     // histograms
     TH1D** fh_RawPosMult1;
     char* fOutputFile;
+
+    // fit functions
+    TF1** fitRawPos;
 
   public:
     ClassDef(R3BSofSciTcal2RawPosPar, 0);

--- a/sci/R3BSofSciTcal2RawTofPar.h
+++ b/sci/R3BSofSciTcal2RawTofPar.h
@@ -4,6 +4,7 @@
 #include "FairTask.h"
 #include "TH1D.h"
 #include "TH1F.h"
+#include "TF1.h"
 
 class TClonesArray;
 class R3BSofSciRawTofPar;
@@ -83,6 +84,9 @@ class R3BSofSciTcal2RawTofPar : public FairTask
     TH1D** fh_RawTofMult1;
     char* fOutputFile;
 
+    // fit functions
+    TF1** fitRawTof;
+    
   public:
     ClassDef(R3BSofSciTcal2RawTofPar, 0);
 };

--- a/sofdata/twimData/R3BSofTwimHitData.cxx
+++ b/sofdata/twimData/R3BSofTwimHitData.cxx
@@ -22,4 +22,14 @@ R3BSofTwimHitData::R3BSofTwimHitData(Int_t secID, Double_t theta, Double_t z)
 }
 // -------------------------------------------------------------------------
 
+// -----   For later analysis with reconstructed beta   --------------------
+R3BSofTwimHitData::R3BSofTwimHitData(Int_t secID, Double_t theta, Double_t z, Double_t ene)
+  : fSecID(secID)
+  , fTheta(theta)
+  , fZ(z)
+  , fE(ene)
+{
+}
+// -------------------------------------------------------------------------
+
 ClassImp(R3BSofTwimHitData)

--- a/sofdata/twimData/R3BSofTwimHitData.h
+++ b/sofdata/twimData/R3BSofTwimHitData.h
@@ -20,6 +20,7 @@ class R3BSofTwimHitData : public TObject
      *@param z        Atomic number Z in charge units
      **/
     R3BSofTwimHitData(Int_t secID, Double_t theta, Double_t z);
+    R3BSofTwimHitData(Int_t secID, Double_t theta, Double_t z, Double_t ene);
 
     /** Destructor **/
     virtual ~R3BSofTwimHitData() {}
@@ -28,15 +29,17 @@ class R3BSofTwimHitData : public TObject
     inline const Int_t& GetSecID() const { return fSecID; }
     inline const Double_t& GetTheta() const { return fTheta; }
     inline const Double_t& GetZcharge() const { return fZ; }
+    inline const Double_t& GetEave() const { return fE; }
 
     /** Modifiers **/
     void SetSecID(Int_t id) { fSecID = id; };
     void SetTheta(Double_t theta) { fTheta = theta; };
     void SetZcharge(Double_t z) { fZ = z; };
+    void SetEave(Double_t ene) { fE = ene; };
 
   protected:
     Int_t fSecID;
-    Double_t fTheta, fZ;
+    Double_t fTheta, fZ, fE;
 
   public:
     ClassDef(R3BSofTwimHitData, 1)

--- a/sofonline/R3BSofOnlineSpectra.cxx
+++ b/sofonline/R3BSofOnlineSpectra.cxx
@@ -346,7 +346,8 @@ InitStatus R3BSofOnlineSpectra::Init()
     fh1_wrs[1] = new TH1F("fh1_WR_Sofia_Califa_Messel", "", 1200, -4100, 4100);
     fh1_wrs[1]->SetLineColor(4);
     fh1_wrs[1]->SetLineWidth(3);
-    fh1_wrs[1]->Draw("same");
+    if(fWRItemsCalifa)
+      fh1_wrs[1]->Draw("same");
     fh1_wrs[2] = new TH1F("fh1_WR_Sofia_Neuland", "", 1200, -4100, 4100);
     fh1_wrs[2]->SetLineColor(3);
     fh1_wrs[2]->SetLineWidth(3);
@@ -508,16 +509,20 @@ void R3BSofOnlineSpectra::Exec(Option_t* option)
     // Fill histogram with trigger information
 
     Int_t tpatbin;
-    for (Int_t i = 0; i < 16; i++)
-    {
-        tpatbin = (fEventHeader->GetTpat() & (1 << i));
-        if (tpatbin != 0)
+    if(fEventHeader->GetTpat()>0){
+      for (Int_t i = 0; i < 16; i++)
+	{
+	  tpatbin = (fEventHeader->GetTpat() & (1 << i));
+	  if (tpatbin != 0)
             fh1_trigger->Fill(i + 1);
+	}
+    }else if(fEventHeader->GetTpat()==0){
+      fh1_trigger->Fill(0);
+    }else{
+      LOG(INFO) <<  fNEvents << " "<< fEventHeader->GetTpat();
     }
-
     // fh1_trigger->Fill(fEventHeader->GetTpat());
 
-    // LOG(INFO) <<  fEventHeader->GetTpat();
 
     // WR data
     if (fWRItemsSofia && fWRItemsSofia->GetEntriesFast() > 0)
@@ -637,10 +642,10 @@ void R3BSofOnlineSpectra::FinishTask()
 {
     // Write trigger canvas in the root file
     cTrigger->Write();
-    if (fWRItemsMaster && fWRItemsSofia)
+    if (fWRItemsMaster && fWRItemsSofia){
         cWr->Write();
-    if (fWRItemsCalifa && fWRItemsSofia)
-        cWrs->Write();
+	cWrs->Write();
+    }
 }
 
 ClassImp(R3BSofOnlineSpectra)

--- a/sofonline/R3BSofTwimvsMusicOnlineSpectra.cxx
+++ b/sofonline/R3BSofTwimvsMusicOnlineSpectra.cxx
@@ -96,6 +96,20 @@ InitStatus R3BSofTwimvsMusicOnlineSpectra::Init()
     char Name2[255];
 
     // Hit data
+    TCanvas* c_E = new TCanvas("Charge_e_correlation", "Music #sqrt{E} correlation", 10, 10, 800, 700);
+    fh2_hit_e = new TH2F("fh2_Twim_vs_Music_charge_e", "Twim vs Music: #sqrt{E}", 1000, 0, 100, 1000, 0, 100);
+    fh2_hit_e->GetXaxis()->SetTitle("Music #sqrt{E}");
+    fh2_hit_e->GetYaxis()->SetTitle("Twim #sqrt{E}");
+    fh2_hit_e->GetYaxis()->SetTitleOffset(1.1);
+    fh2_hit_e->GetXaxis()->SetTitleOffset(1.);
+    fh2_hit_e->GetXaxis()->CenterTitle(true);
+    fh2_hit_e->GetYaxis()->CenterTitle(true);
+    fh2_hit_e->GetXaxis()->SetLabelSize(0.045);
+    fh2_hit_e->GetXaxis()->SetTitleSize(0.045);
+    fh2_hit_e->GetYaxis()->SetLabelSize(0.045);
+    fh2_hit_e->GetYaxis()->SetTitleSize(0.045);
+    fh2_hit_e->Draw("col");
+
     TCanvas* c_Z = new TCanvas("Charge_z_correlation", "Charge Z correlation", 10, 10, 800, 700);
     fh2_hit_z = new TH2F("fh2_Twim_vs_Music_charge_z", "Twim vs Music: Charge Z", 1000, 6, 38, 1000, 6, 38);
     fh2_hit_z->GetXaxis()->SetTitle("Music charge (Z)");
@@ -130,6 +144,7 @@ InitStatus R3BSofTwimvsMusicOnlineSpectra::Init()
     TFolder* mainfolTwim = new TFolder("TWIM_vs_MUSIC", "TWIM vs MUSIC info");
     if (fHitItemsTwim && fHitItemsMusic)
     {
+        mainfolTwim->Add(c_E);
         mainfolTwim->Add(c_Z);
         mainfolTwim->Add(c_theta);
     }
@@ -147,7 +162,8 @@ void R3BSofTwimvsMusicOnlineSpectra::Reset_Histo()
 
     if (fHitItemsTwim && fHitItemsMusic)
     {
-        fh2_hit_z->Reset();
+        fh2_hit_e->Reset();
+	fh2_hit_z->Reset();
         fh2_hit_theta->Reset();
     }
 }
@@ -161,7 +177,7 @@ void R3BSofTwimvsMusicOnlineSpectra::Exec(Option_t* option)
     // Fill hit data
     if (fHitItemsTwim && fHitItemsTwim->GetEntriesFast() > 0 && fHitItemsMusic && fHitItemsMusic->GetEntriesFast() > 0)
     {
-        Float_t z1 = 0., z2 = 0., theta1 = 0., theta2 = 0.;
+      Float_t e1 = 0., e2 = 0., z1 = 0., z2 = 0., theta1 = 0., theta2 = 0.;
         // MUSIC
         Int_t nHits1 = fHitItemsMusic->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits1; ihit++)
@@ -169,6 +185,7 @@ void R3BSofTwimvsMusicOnlineSpectra::Exec(Option_t* option)
             R3BMusicHitData* hit = (R3BMusicHitData*)fHitItemsMusic->At(ihit);
             if (!hit)
                 continue;
+	    e1 = hit->GetEave();
             z1 = hit->GetZcharge();
             theta1 = hit->GetTheta() * 1000.; // mrad
         }
@@ -179,10 +196,12 @@ void R3BSofTwimvsMusicOnlineSpectra::Exec(Option_t* option)
             R3BSofTwimHitData* hit = (R3BSofTwimHitData*)fHitItemsTwim->At(ihit);
             if (!hit)
                 continue;
+	    e2 = hit->GetEave();
             z2 = hit->GetZcharge();
             theta2 = hit->GetTheta() * 1000.; // mrad
         }
         // Fill histograms
+        fh2_hit_e->Fill(TMath::Sqrt(e1), TMath::Sqrt(e2));
         fh2_hit_z->Fill(z1, z2);
         fh2_hit_theta->Fill(theta1, theta2);
     }
@@ -206,7 +225,8 @@ void R3BSofTwimvsMusicOnlineSpectra::FinishTask()
 {
     if (fHitItemsTwim && fHitItemsMusic)
     {
-        fh2_hit_z->Write();
+        fh2_hit_e->Write();
+	fh2_hit_z->Write();
         fh2_hit_theta->Write();
     }
 }

--- a/sofonline/R3BSofTwimvsMusicOnlineSpectra.h
+++ b/sofonline/R3BSofTwimvsMusicOnlineSpectra.h
@@ -90,6 +90,7 @@ class R3BSofTwimvsMusicOnlineSpectra : public FairTask
     Int_t fNEvents;         /**< Event counter.     */
 
     // Histograms for Hit data
+    TH2F* fh2_hit_e;
     TH2F* fh2_hit_z;
     TH2F* fh2_hit_theta;
 

--- a/twim/R3BSofTwimCal2Hit.cxx
+++ b/twim/R3BSofTwimCal2Hit.cxx
@@ -258,7 +258,7 @@ void R3BSofTwimCal2Hit::Exec(Option_t* option)
             Double_t zhit =
                 fZ0 + fZ1 * TMath::Sqrt(Esum / nba) + fZ2 * TMath::Sqrt(Esum / nba) * TMath::Sqrt(Esum / nba);
             if (zhit > 0 && theta > -5000.)
-                AddHitData(i, theta, zhit);
+	      AddHitData(i, theta, zhit, Esum / nba);
         }
     }
 
@@ -285,4 +285,12 @@ R3BSofTwimHitData* R3BSofTwimCal2Hit::AddHitData(UShort_t secid, Double_t theta,
     TClonesArray& clref = *fTwimHitDataCA;
     Int_t size = clref.GetEntriesFast();
     return new (clref[size]) R3BSofTwimHitData(secid, theta, charge_z);
+}
+// -----   For later analysis with reconstructed beta -----
+R3BSofTwimHitData* R3BSofTwimCal2Hit::AddHitData(UShort_t secid, Double_t theta, Double_t charge_z, Double_t ene_ave)
+{
+  // It fills the R3BSofTwimHitData
+  TClonesArray& clref = *fTwimHitDataCA;
+  Int_t size = clref.GetEntriesFast();
+  return new (clref[size]) R3BSofTwimHitData(secid, theta, charge_z, ene_ave);
 }

--- a/twim/R3BSofTwimCal2Hit.h
+++ b/twim/R3BSofTwimCal2Hit.h
@@ -72,6 +72,7 @@ class R3BSofTwimCal2Hit : public FairTask
     /** Private method TwimHitData **/
     //** Adds a TwimHitData to the detector
     R3BSofTwimHitData* AddHitData(UShort_t secID, Double_t theta, Double_t charge_z);
+    R3BSofTwimHitData* AddHitData(UShort_t secID, Double_t theta, Double_t charge_z, Double_t ene_ave);
 
   public:
     // Class definition


### PR DESCRIPTION
Bug fix in TPAT reconstructions in main_online.C and R3BSofOnlineSpectra.cxx

The R3BSofSciTcal2RawPos/TofPar classes are now using Gaussian fit of the peak for accurate analysis. +/- 5 sigma range is now applied.

Simplified the reconstruction algorithm of R3BSofSciTcal2SingleTcal. Now the S2 SofSci and the S8 FRS scintillator are used equally.
The multiplicity of CaveC start plastic is defined as the smaller one of either S2-CaveC or S8-CaveC ToF to recover missing events due to high rate at S2.

Modification in the classes for Twim. For the dedicated analysis getting rid of the beta dependency, it is necessary to provide averaged energy for outside of the class.
A similar modification has been applied in the r3bmusic classes, in the R3BRoot repository.