### PR TITLE
Removed 'delete fEventHeader' in destructor functions as fEventHeader…

### DIFF
--- a/sofonline/R3BSofSciOnlineSpectra.cxx
+++ b/sofonline/R3BSofSciOnlineSpectra.cxx
@@ -84,8 +84,6 @@ R3BSofSciOnlineSpectra::R3BSofSciOnlineSpectra(const char* name, Int_t iVerbose)
 R3BSofSciOnlineSpectra::~R3BSofSciOnlineSpectra()
 {
     LOG(INFO) << "R3BSofSciOnlineSpectra::Delete instance";
-    if (fEventHeader)
-        delete fEventHeader;
     if (fMapped)
         delete fMapped;
     if (fTcal)

--- a/sofsource/R3BSofWhiterabbitReader.cxx
+++ b/sofsource/R3BSofWhiterabbitReader.cxx
@@ -34,8 +34,6 @@ R3BSofWhiterabbitReader::~R3BSofWhiterabbitReader()
     LOG(DEBUG) << "R3BSofWhiterabbitReader: Delete instance";
     if (fArray)
         delete fArray;
-    if (fEventHeader)
-        delete fEventHeader;
 }
 
 Bool_t R3BSofWhiterabbitReader::Init(ext_data_struct_info* a_struct_info)


### PR DESCRIPTION
… is not constructed anymore in the R3BRoot, but in macros.

These lines caused segmentation fault when using FairSoft_nov20, FairRoot18.4.2, and GCC9.3.0 on Ubuntu20.4.5 system.